### PR TITLE
When including an external file, only .html files are parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = () => {
   }
 
   function translateIncludeFile($, basepath) {
-    let $el, includeFilePath, includeFileContent, includeDom;
+    let $el, includeFilePath, includeFileContent, includeFileType, includeDom;
 
     $('include-file').each((i, el) => {
       $el = $(el);
@@ -90,7 +90,12 @@ module.exports = () => {
       if (!isFile(includeFilePath)) return $;
 
       includeFileContent = readFile(includeFilePath);
-      includeDom = $(includeFileContent);
+
+      includeFileType = includeFilePath.substring(includeFilePath.lastIndexOf('.')+1, includeFilePath.length) || includeFilePath;
+
+      if ( includeFileType.toLowerCase == "html" ) includeDom = $(includeFileContent);
+      else includeDom = includeFileContent;
+
       $el.replaceWith(includeDom);
     });
 


### PR DESCRIPTION
Hi!
Just added this smalll modification to the code. Long history short, I want to include CSS and JS file directly into the template, but the current version always try to parse the external file as HTML.

This patch limits that functionality only to HTML files, other files are pasted into the code without any parsing.